### PR TITLE
Resolve #39

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,7 @@ title: App Compatibility without Play Services
 description: A collection of apps tested for Android which works without Play Services
 repo: "https://github.com/DevDude437/App-Compatibility-without-Google-Play-Services"
 
+theme_colour: "#3076cb"
+
 collections:
   - apps

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="{{ site.description }}">
+        <meta name="theme-color" content="{{ site.theme_colour }}">
         <script>
             const APPS = [
                 {% for app in site.apps %}


### PR DESCRIPTION
# Info

## Description
*What does this PR do?*

Add primitive support for `<meta name="theme-color" />` element.

## Related issue

*Put the `Closes` keyword along with the issue number below here.*

Closes #39

## Type of change

⬜️ New Entry  

⬜️ Fix/update to existing entry  

✅ Other (explain)
 
## Checklist

✅ I followed the app entry format as defined in `CONTRIBUTING.md`  
✅ This app submitted fulfills the **App Submission Requirements** section found in `CONTRIBUTING.md`

## Notes for reviewers/additional context

*Add any important notes, caveats, or manual steps reviewers should be aware of below*

The "theme colour" only shows up on mobile Chromium (Android) currently, and in the past, Safari (but not anymore).